### PR TITLE
Fix parsing of remote policies

### DIFF
--- a/path_roles.go
+++ b/path_roles.go
@@ -44,7 +44,7 @@ as a trusted actor.`,
 				Description: "JSON of policies to be dynamically applied to users of this role.",
 			},
 			"remote_policies": {
-				Type: framework.TypeCommaStringSlice,
+				Type: framework.TypeStringSlice,
 				Description: `The name and type of each remote policy to be applied. 
 Example: "name:AliyunRDSReadOnlyAccess,type:System".`,
 			},

--- a/test_env.go
+++ b/test_env.go
@@ -141,7 +141,10 @@ func (e *testEnv) AddPolicyBasedRole(t *testing.T) {
 		Path:      "role/policy-based",
 		Storage:   e.Storage,
 		Data: map[string]interface{}{
-			"remote_policies": []string{"name:AliyunOSSReadOnlyAccess,type:System"},
+			"remote_policies": []string{
+				"name:AliyunOSSReadOnlyAccess,type:System",
+				"name:AliyunRDSReadOnlyAccess,type:System",
+			},
 			"inline_policies": rawInlinePolicies,
 		},
 	}
@@ -203,12 +206,22 @@ func (e *testEnv) ReadPolicyBasedRole(t *testing.T) {
 	}
 
 	remotePolicies := resp.Data["remote_policies"].([]*remotePolicy)
-	for _, remotePol := range remotePolicies {
-		if remotePol.Name != "AliyunOSSReadOnlyAccess" {
-			t.Fatalf("received unexpected policy name of %s", remotePol.Name)
-		}
-		if remotePol.Type != "System" {
-			t.Fatalf("received unexpected policy type of %s", remotePol.Type)
+	for i, remotePol := range remotePolicies {
+		switch i {
+		case 0:
+			if remotePol.Name != "AliyunOSSReadOnlyAccess" {
+				t.Fatalf("received unexpected policy name of %s", remotePol.Name)
+			}
+			if remotePol.Type != "System" {
+				t.Fatalf("received unexpected policy type of %s", remotePol.Type)
+			}
+		case 1:
+			if remotePol.Name != "AliyunRDSReadOnlyAccess" {
+				t.Fatalf("received unexpected policy name of %s", remotePol.Name)
+			}
+			if remotePol.Type != "System" {
+				t.Fatalf("received unexpected policy type of %s", remotePol.Type)
+			}
 		}
 	}
 


### PR DESCRIPTION
Fixes https://github.com/hashicorp/vault/issues/8256

Because an example remote policy is `name:AliyunRDSReadOnlyAccess,type:System` using a `TypeCommaStringSlice` was not appropriate because a comma is used as part of each remote policy. It caused incorrect behavior when only sending 1 remote policy. 