### PR TITLE
Fix the build script

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -45,7 +45,7 @@ ${GO_CMD} build \
     -ldflags "-X github.com/hashicorp/${TOOL}/version.GitCommit='${GIT_COMMIT}${GIT_DIRTY}'" \
     -o "bin/${TOOL}" \
     -tags "${BUILD_TAGS}" \
-    .
+    "${DIR}/cmd/${TOOL}"
 
 # Move all the compiled things to the $GOPATH/bin
 OLDIFS=$IFS


### PR DESCRIPTION
# Overview

Today, running `make dev` on this repository results in a non-executable file:

```
$ make dev
$ ls -l bin/vault-plugin-secrets-alicloud
-rw-r--r--@ 1   1057326  7 Apr 19:08 bin/vault-plugin-secrets-alicloud
```

With the change, the file is executable and is of correct size:

```sh
$ make dev
$ ls -l bin/vault-plugin-secrets-alicloud
-rwxr-xr-x@ 1  25249410  7 Apr 19:11 bin/vault-plugin-secrets-alicloud
```

# Design of Change

I copied the line from https://github.com/hashicorp/vault-plugin-auth-alicloud/blob/c41d48b/scripts/build.sh#L48, an equivalent script in the `auth` sibling plugin.
