### PR TITLE
chore: bump and pin github actions

### DIFF
--- a/.github/workflows/acc-tests.yaml
+++ b/.github/workflows/acc-tests.yaml
@@ -14,8 +14,8 @@ jobs:
       VAULT_SECRETS_ACC_TEST_ACCESS_KEY_ID: ${{ secrets.VAULT_SECRETS_ACC_TEST_ACCESS_KEY_ID }}
       VAULT_SECRETS_ACC_TEST_SECRET_KEY: ${{ secrets.VAULT_SECRETS_ACC_TEST_SECRET_KEY }}
     steps:
-    - uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3 # v3.5.0
-    - uses: actions/setup-go@4d34df0c2316fe8122ab82dc22947d607c0c91f9 # v4.0.0
+    - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
+    - uses: actions/setup-go@cdcb36043654635271a94b9a6d1392de5bb323a7 # v5.0.1
       with:
         go-version-file: .go-version
         cache: true


### PR DESCRIPTION
Update actions and pin to prepare for node16 EOL